### PR TITLE
Fix Error: TNaN is not a valid duration

### DIFF
--- a/libCCMZ.js
+++ b/libCCMZ.js
@@ -120,7 +120,7 @@ const libCCMZ = {
         });
         let tickPos = tempoTicks.indexOf(event['tick']);
         let currTempo = baseTempo;
-        let mDuration, mTick = 1;
+        let mDuration = 1, mTick = 1;
         if (tickPos != 0) {
           let thisTick = tempoTicks[tickPos-1];
           let lastTempo = baseTempo;


### PR DESCRIPTION
This fixes hexadecimal233#8 issue.

/home/pi/chongchong-free/node_modules/midi-writer-js/build/index.js:355
          throw new Error(duration + ' is not a valid duration.');
                ^

Error: TNaN is not a valid duration.
    at Function.getTickDuration (/home/pi/chongchong-free/node_modules/midi-writer-js/build/index.js:355:17)
    at new NoteEvent (/home/pi/chongchong-free/node_modules/midi-writer-js/build/index.js:794:31)
    at Object.writeMIDI (/home/pi/chongchong-free/libCCMZ.js:145:20)
    at writeAndConvert (/home/pi/chongchong-free/functions.js:26:17)
    at /home/pi/chongchong-free/libCCMZ.js:56:17